### PR TITLE
fix: avoid requirements.txt cannot be detect during pip install

### DIFF
--- a/.github/workflows/pub-to-pypi.yml
+++ b/.github/workflows/pub-to-pypi.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e .
       - name: update version
         run: python get_latest_version.py
       - name: install deployment dependancies

--- a/.github/workflows/pub-to-pypi.yml
+++ b/.github/workflows/pub-to-pypi.yml
@@ -1,6 +1,7 @@
 name: Publish Python distributions to PyPI
 on:
   pull_request:
+    types: [closed]
     branches:
       - main
 jobs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-execnet
-requests
-scalable-cuckoo-filter
-tqdm
-urllib3
-autopep8

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ with open("README.md", "r") as fh:
 
     long_description = fh.read()
 
-with open('requirements.txt', 'r') as f:
-    install_requires = [ln.replace('\n', '') for ln in f]
 
 with open(str(pathlib.Path(__file__).parent.absolute()) +
           "/jsonschema_inference/version.py", "r") as fh:
@@ -54,7 +52,14 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     tests_require=['pytest'],
-    install_requires=install_requires,
+    install_requires=[
+        'execnet',
+        'requests',
+        'scalable-cuckoo-filter',
+        'tqdm',
+        'urllib3',
+        'autopep8'
+    ],
     entry_points={
         'console_scripts': [
             'jsonschema-inference = \


### PR DESCRIPTION
fix: avoid requirements.txt cannot be detect during pip install